### PR TITLE
iOS Redirect URI Mismatch: callback.not.match Error in UAE Pass Flutter SDK

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,6 +34,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace 'com.mvpapps.uae_pass_flutter'
     compileSdkVersion 31
 
     compileOptions {

--- a/ios/Classes/UaePassPlugin.swift
+++ b/ios/Classes/UaePassPlugin.swift
@@ -36,11 +36,12 @@ public class UaePassPlugin: NSObject, FlutterPlugin {
         let environment = arguments["environment"] as! String
         let env = environment == "production" ? UAEPASSEnvirnonment.production : UAEPASSEnvirnonment.staging
         let redirectUriLogin = arguments["redirect_uri_login"] as! String
+        let redirectUrlCallBack = arguments["redirect_url"] as! String
         let state = arguments["state"] as! String
         let scope = arguments["scope"] as! String
         UAEPASSRouter.shared.environmentConfig = UAEPassConfig(clientID: clientID, clientSecret: clientSecret, env: env)
 
-        UAEPASSRouter.shared.spConfig = SPConfig(redirectUriLogin: "https://oauthtest.com/authorization/return",
+        UAEPASSRouter.shared.spConfig = SPConfig(redirectUriLogin: redirectUrlCallBack,
                                                  scope: scope,
                                                  state:state,  
                                                  successSchemeURL: redirectUriLogin+"://",


### PR DESCRIPTION
The UAE Pass Flutter SDK works perfectly on Android but fails on iOS with a **`callback.not.match`** error. This occurs because the SDK hardcodes the redirectUrl in SPConfig to https://oauthtest.com/authorization/return, which does not match the custom redirect URI provided during setup (e.g., myapp://callback).
When I replace the hardcoded URL with my app’s redirect URI, the issue is resolved. 

**Issue Details
Code in Flutter (Calling setUpEnvironment)**
When calling the setUpEnvironment function from Flutter: Configure the SDK with a custom redirect URI provided by UAE pass team
  
 ```
  await _uaePassPlugin.setUpEnvironment(
  'xxxxxxx', //"< client Id here >",
  'xxxxxxxxx',  //"< client secret here >",
  'myapp', //"< redirect url scheme here >",
  '123123213', // "< state here >",
  scope: 'urn:uae:digitalid:profile, // "< scope here >",
  isProduction: false, // set to false for sandbox
  redirectUri:'myapp://callback', // "< redirect url here >",
);
```

Here, redirectUri (myapp://callback) is passed to the iOS platform via the method channel.

**Code in iOS (Incorrect Data Fetching)**
In the iOS plugin (UaePassPlugin.swift), the method extracts parameters like this:


```
 if let arguments = call.arguments as? [String: Any] {
    let clientID = arguments["client_id"] as! String
    let clientSecret = arguments["client_secret"] as! String
    let environment = arguments["environment"] as! String
    let env = environment == "production" ? UAEPASSEnvirnonment.production : UAEPASSEnvirnonment.staging
    let redirectUriLogin = arguments["redirect_uri_login"] as! String
    let state = arguments["state"] as! String
    let scope = arguments["scope"] as! String

    UAEPASSRouter.shared.environmentConfig = UAEPassConfig(clientID: clientID, clientSecret: clientSecret, env: env)

    UAEPASSRouter.shared.spConfig = SPConfig(
        redirectUriLogin: "https://oauthtest.com/authorization/return",
        scope: scope,
        state: state,
        successSchemeURL: redirectUriLogin + "://",
        failSchemeURL: redirectUriLogin + "://",
        signingScope: "urn:safelayer:eidas:sign:process:document"
    )
}
```

The value being used in SPConfig is hardcoded as "https://oauthtest.com/authorization/return" instead of fetching the correct redirectUri.

**Proposed Fix**
To correctly retrieve and use the redirectUri from Flutter, update the iOS code to fetch "redirect_url" properly:
 
```
        if let arguments = call.arguments as? [String: Any] {
        ......// other codes
        let redirectUrlCallBack = arguments["redirect_url"] as! String  //new: fetch redirect_url from setup
      
        UAEPASSRouter.shared.environmentConfig = UAEPassConfig(clientID: clientID, clientSecret: clientSecret, env: env)

        UAEPASSRouter.shared.spConfig = SPConfig(redirectUriLogin: redirectUrlCallBack, //update url here
                                                 .....
```

**Why This Fix Works**

- Ensures that redirect_url is correctly retrieved from the Flutter method call (arguments["redirect_url"]).
- Removes hardcoded redirectUriLogin and replaces it with redirectUrlCallBack, which is correctly passed from Flutter.
- Updates successSchemeURL and failSchemeURL to use redirectUrlCallBack, ensuring proper OAuth redirection.


